### PR TITLE
add Dockerfile to support OpenROAD unified build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+.git
+.gitignore
+Dockerfile
+
+# from .gitignore
+defs.mak
+Depend
+config.cache
+config.log
+scripts/config.log
+scripts/config.status
+scripts/defs.mak
+.*.swp
+*.o
+*.so
+*~
+scmos/cif_template/objs/*
+UPDATE_ME
+VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:centos6 AS builder
+
+# Common development tools and libraries (kitchen sink approach)
+RUN yum groupinstall -y "Development Tools" "Development Libraries"
+
+# magic dependencies
+RUN yum install -y csh wget tcl-devel tk-devel libX11-devel cairo-devel ncurses-devel
+
+COPY . /magic
+WORKDIR /magic
+
+RUN ./configure --prefix=/build && \
+    make && \
+    make install
+
+FROM centos:centos6 AS runner
+RUN yum update -y && yum install -y tcl-devel
+COPY --from=builder /build /build
+RUN useradd -ms /bin/bash openroad
+USER openroad
+WORKDIR /home/openroad
+


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository to integrate in the unified build environment. The image is based on centos6, which is the agreed build environment for OpenROAD.

To build:
`docker build -t <image_name> .`

Binaries are in `/build` directory, which can also be run from within the container.